### PR TITLE
Fix sim2b-config.cmake.in

### DIFF
--- a/sim2b-config.cmake.in
+++ b/sim2b-config.cmake.in
@@ -9,7 +9,9 @@ set(@PROJECT_NAME@_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
 if(NOT @PROJECT_NAME@_BINARY_DIR)
-  include("${@PROJECT_NAME@_CMAKE_DIR}/@PROJECT_NAME@-targets.cmake")
+  foreach(library @EXPORTED_LIBRARIES@)
+    include("${@PROJECT_NAME@_CMAKE_DIR}/${library}-targets.cmake")
+  endforeach()
 endif()
 
 # These are IMPORTED targets created by @PROJECT_NAME@-targets.cmake


### PR DESCRIPTION
The project does not have a "primary library", so including `@PRJECT_NAME@-targets.cmake` fails. Include the `-targets.cmake` file for each exported library instead.