### PR TITLE
sim2b: add bullet and bullet_robotics CFLAGS

### DIFF
--- a/src/nbx/CMakeLists.txt
+++ b/src/nbx/CMakeLists.txt
@@ -19,6 +19,10 @@ if(ENABLE_BULLET)
     ${BULLET_ROBOTICS_LIBRARIES}
   )
 
+  target_compile_options(sim2b_bullet PUBLIC
+    ${BULLET_CFLAGS}
+    ${BULLET_ROBOTICS_CFLAGS}
+  )
 
   install(
     TARGETS sim2b_bullet


### PR DESCRIPTION
Among others flags, this adds BT_USE_DOUBLE_PRECISION
to sim2b_bullet if that flag was also used to compile libbullet. If these
don't match, the simulation will just produce nan's.

Suggested-by: Sven Schneider <sven.schneider@h-brs.de>
Signed-off-by: Markus Klotzbuecher <mk@mkio.de>